### PR TITLE
use puppet's --debug option if ${LOGLEVEL} is set to DEBUG

### DIFF
--- a/puppet-apply-step/contents/puppet_apply
+++ b/puppet-apply-step/contents/puppet_apply
@@ -18,7 +18,7 @@ else PUPPET_CMD="puppet apply"
 fi
 
 if [[ "${LOGLEVEL}" == DEBUG ]]
-then PUPPET_CMD="$PUPPET_CMD --verbose"
+then PUPPET_CMD="$PUPPET_CMD --debug"
 fi
 
 printf >&2 "Executing : $PUPPET_CMD $@ $MANIFEST\n"


### PR DESCRIPTION
I may be unique, but I use puppet's --debug option when I need to understand what's going on under the covers.  Changed to use --debug if ${LOGLEVEL} is set to DEBUG
